### PR TITLE
Fast listen off

### DIFF
--- a/config/base.cfg
+++ b/config/base.cfg
@@ -10,6 +10,7 @@ show-picked-versions = true
 [settings]
 main-package = Euphorie
 http-address =
+http-fast-listen = off
 
 zeo-address = ${buildout:directory}/var/zeo.socket
 file-storage = ${buildout:directory}/var/filestorage/Data.fs
@@ -31,6 +32,7 @@ zeopack-script-name = zeopacker
 recipe = plone.recipe.zope2instance
 user = admin:admin
 http-address = ${settings:http-address}
+http-fast-listen = ${settings:http-fast-listen}
 zeo-client = on
 zeo-address = ${settings:zeo-address}
 shared-blob = on

--- a/config/base.cfg
+++ b/config/base.cfg
@@ -9,7 +9,7 @@ show-picked-versions = true
 
 [settings]
 main-package = Euphorie
-http-address =
+http-address = 8080
 http-fast-listen = off
 
 zeo-address = ${buildout:directory}/var/zeo.socket


### PR DESCRIPTION
This avoids 100% CPU usage on restart in same conditions.

See: plone/plone.recipe.zope2instance#188