### PR TITLE
Add profile that does not build zeo

### DIFF
--- a/profiles/nozeo.cfg
+++ b/profiles/nozeo.cfg
@@ -1,0 +1,9 @@
+[buildout]
+extends =
+    config/base.cfg
+    custom.cfg
+
+[supervisor]
+=> instance
+programs =
+    100 instance ${buildout:directory}/bin/instance [console] ${buildout:directory} true


### PR DESCRIPTION
This is not particularly intuitive. Maybe the default should be not to build zeo, and the profiles should add it explicitly if they want it?

Refs syslabcom/scrum#2176