### PR TITLE
Use plone.autoinclude 2.0.0

### DIFF
--- a/config/base.cfg
+++ b/config/base.cfg
@@ -126,7 +126,7 @@ setuptools =
 zc.buildout =
 
 # Remove for Plone > 6.0.14
-# No package to remove
+plone.autoinclude = 2.0.0
 
 # We still do not support SQLAlchemy 2
 SQLAlchemy = 1.4.52


### PR DESCRIPTION
Use plone.autoinclude 2.0.0 to prevent issues at startup (see https://github.com/plone/plone.autoinclude/issues/25)