### PR TITLE
Use plone.autoinclude = 2.0.3

### DIFF
--- a/config/base.cfg
+++ b/config/base.cfg
@@ -126,7 +126,7 @@ setuptools =
 zc.buildout =
 
 # Remove for Plone > 6.0.14
-plone.autoinclude = 2.0.2
+plone.autoinclude = 2.0.3
 
 # We still do not support SQLAlchemy 2
 SQLAlchemy = 1.4.52

--- a/config/base.cfg
+++ b/config/base.cfg
@@ -126,7 +126,7 @@ setuptools =
 zc.buildout =
 
 # Remove for Plone > 6.0.14
-plone.autoinclude = 2.0.0
+plone.autoinclude = 2.0.2
 
 # We still do not support SQLAlchemy 2
 SQLAlchemy = 1.4.52


### PR DESCRIPTION
We might also need to change the requirements like this if we have issues like "package not found" and so...
```
# -r https://dist.plone.org/release/6.0.14/requirements.txt
# Temporarily use more recent versions of the packages in order to have a working buildout/setuptools/wheel/autoinclude combination
-r https://raw.githubusercontent.com/plone/buildout.coredev/9f91d323727f62c0d1bfcb47ca3337896b3283df/requirements.txt
```