### PR TITLE
Support installations with multiple Plone sites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ buildout_cfgs := $(wildcard *.cfg config/*.cfg profiles/*.cfg)
 
 .PHONY: upgrade
 upgrade:
-	./bin/upgrade plone_upgrade -S &&  ./bin/upgrade install -Sp
+	./bin/upgrade plone_upgrade -A &&  ./bin/upgrade install -Ap
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
From ftw.upgrade help:

```
  --pick-site, -S       Automatically pick the Plone site, when there is exactly one.
  --all-sites, -A       Perform the action on all Plone sites.
```