### PR TITLE
Allow the sources to be customized from the custom.cfg file

### DIFF
--- a/profiles/development.cfg
+++ b/profiles/development.cfg
@@ -16,6 +16,3 @@ eggs +=
 zcml +=
     collective.pdbpp
 deprecation-warnings = on
-
-[sources]
-Euphorie = git git@github.com:euphorie/Euphorie.git branch=main


### PR DESCRIPTION
Otherwise, something like this in the `custom.cfg` will be overwritten:

```ini
[sources]
Euphorie = git git@github.com:euphorie/Euphorie.git branch=another-branch
```